### PR TITLE
Overhaul platform, build/detect API

### DIFF
--- a/examples/example-01-basics/Cargo.lock
+++ b/examples/example-01-basics/Cargo.lock
@@ -28,7 +28,9 @@ version = "0.1.0"
 dependencies = [
  "lazy_static",
  "regex",
+ "semver",
  "serde",
+ "thiserror",
  "toml",
 ]
 
@@ -37,6 +39,15 @@ name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -75,6 +86,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+ "serde",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ef146c2ad5e5f4b037cd6ce2ebb775401729b19a82040c1beac9d36c7d1428"
+dependencies = [
+ "pest",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +136,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +172,12 @@ checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-xid"

--- a/examples/example-01-basics/src/bin/bp_build.rs
+++ b/examples/example-01-basics/src/bin/bp_build.rs
@@ -1,15 +1,14 @@
 use libcnb;
-use std::error::Error;
-use libcnb::shared::GenericPlatform;
-use libcnb::shared::Platform;
-use libcnb::shared::BuildFromPath;
 use libcnb::build::BuildContext;
+use libcnb::platform::{GenericPlatform, Platform};
+use libcnb::shared::BuildpackError;
+use std::error::Error;
 
 fn main() {
     libcnb::build::cnb_runtime_build(build);
 }
 
-fn build(context: BuildContext<GenericPlatform>) -> Result<(), Box<dyn Error>> {
+fn build(context: BuildContext<GenericPlatform>) -> Result<(), std::io::Error> {
     println!("Build runs!");
     Ok(())
 }

--- a/examples/example-01-basics/src/bin/bp_detect.rs
+++ b/examples/example-01-basics/src/bin/bp_detect.rs
@@ -1,16 +1,17 @@
 use libcnb;
-use libcnb::detect::{DetectResult, DetectContext};
 use libcnb::data::build_plan::BuildPlan;
+use libcnb::detect::DetectOutcome;
+use libcnb::detect::GenericDetectContext;
+use libcnb::platform::Platform;
 use libcnb::shared;
-use libcnb::shared::GenericPlatform;
-use libcnb::shared::Platform;
+use std::error::Error;
 
 fn main() {
     libcnb::detect::cnb_runtime_detect(detect)
 }
 
-fn detect(_context: DetectContext<GenericPlatform>) -> DetectResult {
+fn detect(_context: GenericDetectContext) -> Result<DetectOutcome, std::io::Error> {
     let mut buildplan = BuildPlan::new();
 
-    DetectResult::Pass(buildplan)
+    Ok(DetectOutcome::Pass(buildplan))
 }

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,17 +1,17 @@
 use crate::data::buildpack::Buildpack;
 use crate::data::buildpack::BuildpackToml;
 use crate::data::buildpack_plan::BuildpackPlan;
-use crate::shared::Platform;
-use crate::shared::{read_toml_file, BuildFromPath};
+use crate::platform::{GenericPlatform, Platform};
+use crate::shared::{read_toml_file, BuildpackError};
 use std::env;
 use std::fmt::Display;
 use std::path::PathBuf;
 use std::process;
 
 pub fn cnb_runtime_build<
-    E: Display,
+    E: BuildpackError,
     F: Fn(BuildContext<P>) -> Result<(), E>,
-    P: Platform + BuildFromPath,
+    P: Platform,
 >(
     build_fn: F,
 ) {
@@ -41,7 +41,7 @@ pub fn cnb_runtime_build<
             process::exit(1);
         }
 
-        match P::build_from_path(platform_dir.as_path()) {
+        match P::from_path(platform_dir.as_path()) {
             Ok(platform) => platform,
             Err(error) => {
                 eprintln!(
@@ -109,3 +109,5 @@ pub struct BuildContext<P> {
     pub buildpack_plan: BuildpackPlan,
     pub buildpack_descriptor: BuildpackToml,
 }
+
+pub type GenericBuildContext = BuildContext<GenericPlatform>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,5 @@ pub mod data;
 mod error;
 pub use error::Error;
 pub mod detect;
+pub mod platform;
 pub mod shared;

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,0 +1,97 @@
+use std::collections::HashMap;
+use std::env::VarError;
+use std::ffi::{OsStr, OsString};
+use std::fs;
+use std::io;
+use std::path::Path;
+
+/// Represents a Cloud Native Buildpack platform.
+///
+/// Most buildpacks target a generic platform and this library provides a [`GenericPlatform`] for that
+/// use-case. Buildpack authors usually do not need to implement this trait. See
+/// [detection](https://github.com/buildpacks/spec/blob/main/buildpack.md#detection) and
+/// [build](https://github.com/buildpacks/spec/blob/main/buildpack.md#build) in the buildpack
+/// specification for details.
+pub trait Platform
+where
+    Self: Sized,
+{
+    /// Retrieve a [`PlatformEnv`] reference for convenient access to environment variables which
+    /// all platforms have to provide.
+    fn env(&self) -> &PlatformEnv;
+
+    /// Initializes the platform from the given platform directory.
+    ///
+    /// # Examples
+    /// ```no_run
+    ///use libcnb::platform::GenericPlatform;
+    ///let platform = GenericPlatform::from_path("/platform");
+    /// ```
+    fn from_path(platform_dir: impl AsRef<Path>) -> io::Result<Self>;
+}
+
+/// A generic platform that only provides access to environment variables.
+pub struct GenericPlatform {
+    env: PlatformEnv,
+}
+
+impl Platform for GenericPlatform {
+    fn env(&self) -> &PlatformEnv {
+        &self.env
+    }
+
+    fn from_path(platform_dir: impl AsRef<Path>) -> io::Result<Self> {
+        Ok(GenericPlatform {
+            env: PlatformEnv::from_path(platform_dir)?,
+        })
+    }
+}
+
+/// Provides access to platform environment variables.
+pub struct PlatformEnv {
+    vars: HashMap<OsString, String>,
+}
+
+impl PlatformEnv {
+    /// Fetches the environment variable `key` from the platform.
+    ///
+    /// # Examples
+    /// ```no_run
+    ///use libcnb::platform::PlatformEnv;
+    ///let env = PlatformEnv::from_path("/platform")?;
+    ///let value = env.var("SOME_ENV_VAR");
+    /// ```
+    pub fn var<K: AsRef<OsStr>>(&self, key: K) -> Result<String, VarError> {
+        self.vars
+            .get(key.as_ref())
+            .map(|s| s.to_owned())
+            .ok_or(VarError::NotPresent)
+    }
+
+    /// Initializes a new PlatformEnv from the given platform directory.
+    ///
+    /// Buildpack authors usually do not need to create their own [`PlatformEnv`] and instead use the
+    /// one passed via context structs ([`DetectContext`](crate::detect::DetectContext) and [`BuildContext`](crate::build::BuildContext)).
+    ///
+    /// # Examples
+    /// ```no_run
+    ///use libcnb::platform::PlatformEnv;
+    ///let platform = PlatformEnv::from_path("/platform")?;
+    /// ```
+    pub fn from_path(platform_dir: impl AsRef<Path>) -> Result<Self, io::Error> {
+        let env_path = platform_dir.as_ref().join("env");
+        let mut env_vars: HashMap<OsString, String> = HashMap::new();
+
+        for entry in fs::read_dir(env_path)? {
+            let entry = entry?;
+            let path = entry.path();
+
+            if let Some(file_name) = path.file_name() {
+                let file_contents = fs::read_to_string(&path)?;
+                env_vars.insert(file_name.to_owned(), file_contents);
+            }
+        }
+
+        Ok(PlatformEnv { vars: env_vars })
+    }
+}

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -24,8 +24,9 @@ where
     ///
     /// # Examples
     /// ```no_run
+    ///use libcnb::platform::Platform;
     ///use libcnb::platform::GenericPlatform;
-    ///let platform = GenericPlatform::from_path("/platform");
+    ///let platform = GenericPlatform::from_path("/platform").unwrap();
     /// ```
     fn from_path(platform_dir: impl AsRef<Path>) -> io::Result<Self>;
 }
@@ -58,7 +59,7 @@ impl PlatformEnv {
     /// # Examples
     /// ```no_run
     ///use libcnb::platform::PlatformEnv;
-    ///let env = PlatformEnv::from_path("/platform")?;
+    ///let env = PlatformEnv::from_path("/platform").unwrap();
     ///let value = env.var("SOME_ENV_VAR");
     /// ```
     pub fn var<K: AsRef<OsStr>>(&self, key: K) -> Result<String, VarError> {
@@ -76,7 +77,7 @@ impl PlatformEnv {
     /// # Examples
     /// ```no_run
     ///use libcnb::platform::PlatformEnv;
-    ///let platform = PlatformEnv::from_path("/platform")?;
+    ///let platform = PlatformEnv::from_path("/platform").unwrap();
     /// ```
     pub fn from_path(platform_dir: impl AsRef<Path>) -> Result<Self, io::Error> {
         let env_path = platform_dir.as_ref().join("env");

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,58 +1,14 @@
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::collections::HashMap;
+use std::env::VarError;
+use std::error::Error;
+use std::ffi::{OsStr, OsString};
+use std::fmt::Debug;
+use std::fmt::Display;
 use std::fs;
 use std::io;
-use std::path::Path;
-
-pub trait Platform {
-    fn get_env_var(&self, key: &str) -> Option<&str>;
-    fn get_env_vars(&self) -> &HashMap<String, String>;
-
-    fn has_env_var(&self, key: &str) -> bool {
-        self.get_env_var(key).is_some()
-    }
-}
-
-pub trait BuildFromPath
-where
-    Self: Sized,
-{
-    fn build_from_path(path: &Path) -> io::Result<Self>;
-}
-
-pub struct GenericPlatform {
-    env_vars: HashMap<String, String>,
-}
-
-impl Platform for GenericPlatform {
-    fn get_env_var(&self, key: &str) -> Option<&str> {
-        self.env_vars.get(key).map(|value| &value[..])
-    }
-
-    fn get_env_vars(&self) -> &HashMap<String, String> {
-        &self.env_vars
-    }
-}
-
-impl BuildFromPath for GenericPlatform {
-    fn build_from_path(path: &Path) -> Result<Self, io::Error> {
-        let env_path = path.join("env");
-        let mut env_vars: HashMap<String, String> = HashMap::new();
-
-        for entry in fs::read_dir(env_path)? {
-            let entry = entry?;
-            let path = entry.path();
-
-            if let Some(file_name) = path.file_name().and_then(|os_str| os_str.to_str()) {
-                let file_contents = fs::read_to_string(&path)?;
-                env_vars.insert(String::from(file_name), file_contents);
-            }
-        }
-
-        Ok(GenericPlatform { env_vars })
-    }
-}
+use std::path::{Iter, Path};
 
 pub fn write_toml_file(value: &impl Serialize, path: impl AsRef<Path>) -> io::Result<()> {
     // TODO: Fix Result type, remove unwrap
@@ -64,3 +20,7 @@ pub fn read_toml_file<A: DeserializeOwned>(path: impl AsRef<Path>) -> io::Result
     let file_contents = fs::read_to_string(path)?;
     Ok(toml::from_str(file_contents.as_str()).unwrap())
 }
+
+pub trait BuildpackError: Display {}
+
+impl<A: Error> BuildpackError for A {}


### PR DESCRIPTION
- `Platform` now resides in its own file and was overhauled to make implementation of new `Platform`s easier. 
- Introduced `GenericDetectContext` and `GenericBuildContext` for the default use-case. This removes generics for the standard use-case.
- `BuildFromPath` has been removed since we don't need the additional complexity it adds.
- `platform.rs` now has some rustdoc
- Streamlined `detect` and `build` function API, both return a `Result<_, BuildpackError>` now
- Introduced `BuildpackError` trait with implementation for all `std::err::Error` traits. We can add support for error handling frameworks by adding trait implementations for those frameworks.
