### PR TITLE
Tidying up the Build

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -1,7 +1,9 @@
 use crate::{
     data::{buildpack::BuildpackToml, buildpack_plan::BuildpackPlan},
+    layer::Layer,
     platform::{GenericPlatform, Platform},
     shared::{read_toml_file, BuildpackError},
+    Error,
 };
 use std::{env, path::PathBuf, process};
 
@@ -97,7 +99,7 @@ pub fn cnb_runtime_build<
     };
 }
 
-pub struct BuildContext<P> {
+pub struct BuildContext<P: Platform> {
     layers_dir: PathBuf,
     pub app_dir: PathBuf,
     pub buildpack_dir: PathBuf,
@@ -105,6 +107,12 @@ pub struct BuildContext<P> {
     pub platform: P,
     pub buildpack_plan: BuildpackPlan,
     pub buildpack_descriptor: BuildpackToml,
+}
+
+impl<P: Platform> BuildContext<P> {
+    pub fn layer(&self, name: impl AsRef<str>) -> Result<Layer, Error> {
+        Layer::new(name.as_ref(), self.layers_dir.as_path())
+    }
 }
 
 pub type GenericBuildContext = BuildContext<GenericPlatform>;

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,12 +1,9 @@
-use crate::data::buildpack::Buildpack;
-use crate::data::buildpack::BuildpackToml;
-use crate::data::buildpack_plan::BuildpackPlan;
-use crate::platform::{GenericPlatform, Platform};
-use crate::shared::{read_toml_file, BuildpackError};
-use std::env;
-use std::fmt::Display;
-use std::path::PathBuf;
-use std::process;
+use crate::{
+    data::{buildpack::BuildpackToml, buildpack_plan::BuildpackPlan},
+    platform::{GenericPlatform, Platform},
+    shared::{read_toml_file, BuildpackError},
+};
+use std::{env, path::PathBuf, process};
 
 pub fn cnb_runtime_build<
     E: BuildpackError,

--- a/src/data/buildpack_plan.rs
+++ b/src/data/buildpack_plan.rs
@@ -9,5 +9,5 @@ pub struct BuildpackPlan {
 #[derive(Debug, Deserialize)]
 pub struct Entry {
     pub name: String,
-    pub metadata: toml::value::Table,
+    pub metadata: Table,
 }

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -3,7 +3,11 @@ use crate::{
     platform::{GenericPlatform, Platform},
     shared::{write_toml_file, BuildpackError},
 };
-use std::{env, path::PathBuf, process};
+use std::{
+    env,
+    path::{Path, PathBuf},
+    process,
+};
 
 pub fn cnb_runtime_detect<
     P: Platform,
@@ -70,6 +74,16 @@ pub struct DetectContext<P: Platform> {
     app_dir: PathBuf,
     buildpack_dir: PathBuf,
     pub platform: P,
+}
+
+impl<P: Platform> DetectContext<P> {
+    pub fn app_dir(&self) -> &Path {
+        self.app_dir.as_path()
+    }
+
+    pub fn buildpack_dir(&self) -> &Path {
+        self.buildpack_dir.as_path()
+    }
 }
 
 pub type GenericDetectContext = DetectContext<GenericPlatform>;

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -1,14 +1,9 @@
-use crate::data::build_plan::BuildPlan;
-use crate::platform::{GenericPlatform, Platform};
-use crate::shared::write_toml_file;
-use crate::shared::BuildpackError;
-use serde::export::Formatter;
-use std::env;
-use std::error::Error;
-use std::fmt::Display;
-use std::ops::Not;
-use std::path::PathBuf;
-use std::process;
+use crate::{
+    data::build_plan::BuildPlan,
+    platform::{GenericPlatform, Platform},
+    shared::{write_toml_file, BuildpackError},
+};
+use std::{env, path::PathBuf, process};
 
 pub fn cnb_runtime_detect<
     P: Platform,

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,9 +1,10 @@
-use std::collections::HashMap;
-use std::env::VarError;
-use std::ffi::{OsStr, OsString};
-use std::fs;
-use std::io;
-use std::path::Path;
+use std::{
+    collections::HashMap,
+    env::VarError,
+    ffi::{OsStr, OsString},
+    fs, io,
+    path::Path,
+};
 
 /// Represents a Cloud Native Buildpack platform.
 ///

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,15 +1,16 @@
+use crate::Error as CrateError;
 use serde::{de::DeserializeOwned, Serialize};
-use std::{error::Error, fmt::Display, fs, io, path::Path};
+use std::{error::Error, fmt::Display, fs, path::Path};
 
-pub fn write_toml_file(value: &impl Serialize, path: impl AsRef<Path>) -> io::Result<()> {
-    // TODO: Fix Result type, remove unwrap
-    fs::write(path, toml::to_string(value).unwrap())
+pub fn write_toml_file(value: &impl Serialize, path: impl AsRef<Path>) -> Result<(), CrateError> {
+    fs::write(path, toml::to_string(value)?)?;
+
+    Ok(())
 }
 
-pub fn read_toml_file<A: DeserializeOwned>(path: impl AsRef<Path>) -> io::Result<A> {
-    // TODO: Fix Result type, remove unwrap
-    let file_contents = fs::read_to_string(path)?;
-    Ok(toml::from_str(file_contents.as_str()).unwrap())
+pub fn read_toml_file<A: DeserializeOwned>(path: impl AsRef<Path>) -> Result<A, CrateError> {
+    let contents = fs::read_to_string(path)?;
+    Ok(toml::from_str(&contents)?)
 }
 
 pub trait BuildpackError: Display {}

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,14 +1,5 @@
-use serde::de::DeserializeOwned;
-use serde::Serialize;
-use std::collections::HashMap;
-use std::env::VarError;
-use std::error::Error;
-use std::ffi::{OsStr, OsString};
-use std::fmt::Debug;
-use std::fmt::Display;
-use std::fs;
-use std::io;
-use std::path::{Iter, Path};
+use serde::{de::DeserializeOwned, Serialize};
+use std::{error::Error, fmt::Display, fs, io, path::Path};
 
 pub fn write_toml_file(value: &impl Serialize, path: impl AsRef<Path>) -> io::Result<()> {
     // TODO: Fix Result type, remove unwrap


### PR DESCRIPTION
Removed all the warnings from `cargo build`.

* standardize `use` with `{}`
* remove unused imports
* `read_toml_file` and `write_toml_file` now use custom error type (also clean up `unwrap`)
* add accessors on `DetectContext`
* add `layer` fn on `BuildContext`